### PR TITLE
Make LDAPUser.user a FK to settings.AUTH_USER_MODEL

### DIFF
--- a/windows_auth/models.py
+++ b/windows_auth/models.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import Union, Iterable, Optional, Dict
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User, Group
 from django.db import models
@@ -61,7 +62,7 @@ class LDAPUserManager(models.Manager):
 
 
 class LDAPUser(models.Model):
-    user: User = models.OneToOneField(get_user_model(), on_delete=models.CASCADE, related_name="ldap")
+    user: User = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="ldap")
 
     domain: str = models.CharField(max_length=128, help_text="User Domain NetBIOS Name")
 


### PR DESCRIPTION
Currently the field 'user' of the model LDAPUser has a FK to get_user_model(). As a consequence, LDAPUser cannot be subclassed in the Django app that defines the custom User model returned by get_user_model. Importing LDAPUser results in an error due to a circular dependency.

As per the documentation of [get_user_model](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/#django.contrib.auth.get_user_model),

> When you define a foreign key or many-to-many relations to the user model, you should specify the custom model using the [AUTH_USER_MODEL](https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-AUTH_USER_MODEL) setting.

This PR implements this advice, thus allowing LDAPUser to be subclassed.
